### PR TITLE
Control bar links moved to config.json

### DIFF
--- a/public/data/config.json
+++ b/public/data/config.json
@@ -1,37 +1,55 @@
 {
-    "filterCriticalEditions": false,
+    "onlyUseCriticalEditions": false,
+    "controlBarLinks": [
+        {
+            "label": "Download transcript",
+            "property": "transcriptURL"
+        },
+        {
+            "label": "Introduction",
+            "property": "introductionURL"
+        }
+    ],
     "videos": [
         {
             "slug": "hvt-2033",
-            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/vm42r3p97p/manifest"
+            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/vm42r3p97p/manifest",
+            "introductionURL": "https://editions.fortunoff.library.yale.edu/hvt-2033/"
         },
         {
             "slug": "hvt-0170",
-            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/tq5r785x0b/manifest"
+            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/tq5r785x0b/manifest",
+            "introductionURL": "https://editions.fortunoff.library.yale.edu/hvt-0170/"
         },
         {
             "slug": "hvt-3280",
-            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/028pc2t54f/manifest"
+            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/028pc2t54f/manifest",
+            "introductionURL": "https://editions.fortunoff.library.yale.edu/hvt-3280/"
         },
         {
             "slug": "hvt-3038",
-            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/p26pz51s4w/manifest"
+            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/p26pz51s4w/manifest",
+            "introductionURL": "https://editions.fortunoff.library.yale.edu/hvt-3038/"
         },
         {
             "slug": "hvt-0764",
-            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/cr5n87319n/manifest"
+            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/cr5n87319n/manifest",
+            "introductionURL": "https://editions.fortunoff.library.yale.edu/hvt-0764/"
         },
         {
             "slug": "hvt-0237",
-            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/tq5r785x4k/manifest"
+            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/tq5r785x4k/manifest",
+            "introductionURL": "https://editions.fortunoff.library.yale.edu/hvt-0237/"
         },
         {
             "slug": "hvt-3169",
-            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/jw86h4d01m/manifest"
+            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/jw86h4d01m/manifest",
+            "introductionURL": "https://editions.fortunoff.library.yale.edu/hvt-3169/"
         },
         {
             "slug": "hvt-3164",
-            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/5x2599z44f/manifest"
+            "manifestURL": "https://fortunoff.aviaryplatform.com/iiif/5x2599z44f/manifest",
+            "introductionURL": "https://editions.fortunoff.library.yale.edu/hvt-3164/"
         }
     ]
 }

--- a/src/AnnotationViewer/AnnotationViewer.tsx
+++ b/src/AnnotationViewer/AnnotationViewer.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Captions from './Captions/Captions';
 import Player, { PlayerSize } from './Player/Player';
 import style from './AnnotationViewer.module.css';
-import ControlBar from './ControlBar/ControlBar';
+import ControlBar, { ControlBarLinkItem } from './ControlBar/ControlBar';
 import {
   getVideoPartAnnotations,
   getVideoPartCriticalEditionAnnotations,
@@ -16,6 +16,7 @@ interface AnnotationViewerProps {
   manifestURL: string;
   callNumber: string;
   playerSize?: PlayerSize;
+  controlBarLinks: Array<ControlBarLinkItem>;
 }
 
 AnnotationViewer.defaultProps = {
@@ -35,7 +36,7 @@ function AnnotationViewer(props: AnnotationViewerProps) {
   >([]);
   const [annotationSet, setAnnotationSet] = useState<IAnnotationPage>();
 
-  const { manifestURL, callNumber, playerSize } = props;
+  const { manifestURL, callNumber, playerSize, controlBarLinks } = props;
 
   const setPlayerPosition = (seconds: number) => {
     __setPlayerPosition(seconds);
@@ -108,8 +109,8 @@ function AnnotationViewer(props: AnnotationViewerProps) {
         <div className={style.Gray}>
           <div className={style.ControlBarContainer}>
             <ControlBar
-              introductionURL=""
-              downloadTranscriptURL=""
+              // introductionURL=""
+              // downloadTranscriptURL=""
               videoPartList={getVideoParts(manifest as IManifest)}
               setVideoPart={setVideoPart}
               currentVideoPart={videoPart}
@@ -117,6 +118,7 @@ function AnnotationViewer(props: AnnotationViewerProps) {
               currentAnnotationSet={annotationSet}
               setAnnotationSet={setAnnotationSet}
               callNumber={callNumber}
+              links={controlBarLinks}
             />
           </div>
         </div>

--- a/src/AnnotationViewer/ControlBar/ControlBar.tsx
+++ b/src/AnnotationViewer/ControlBar/ControlBar.tsx
@@ -3,6 +3,15 @@ import { IAnnotationPage, IVideoPart } from '../../api/iiifManifest';
 import styles from './ControlBar.module.css';
 import Dropdown from './Dropdown';
 
+export interface ControlBarLinkItem {
+  text: string;
+  href: string;
+}
+
+export interface ControlBarLinkProps {
+  linkItems: Array<ControlBarLinkItem>;
+}
+
 interface ControlBarProps {
   callNumber: string;
   // currentPartNumber: string;
@@ -10,8 +19,10 @@ interface ControlBarProps {
   setVideoPart: (part: IVideoPart) => void;
   currentVideoPart: IVideoPart;
 
-  downloadTranscriptURL: string;
-  introductionURL: string;
+  // downloadTranscriptURL: string;
+  // introductionURL: string;
+
+  links: Array<ControlBarLinkItem>;
 
   annotationSetList: Array<IAnnotationPage>;
   setAnnotationSet: (annotationSet: IAnnotationPage) => void;
@@ -24,11 +35,12 @@ function ControlBar(props: ControlBarProps) {
     currentVideoPart,
     callNumber: hvtID,
     videoPartList: partList,
-    downloadTranscriptURL,
-    introductionURL,
+    // downloadTranscriptURL,
+    // introductionURL,
     annotationSetList,
     setAnnotationSet,
     currentAnnotationSet,
+    links,
   } = props;
 
   return (
@@ -66,13 +78,11 @@ function ControlBar(props: ControlBarProps) {
           }}
         />
       </div>
-      <div>
-        {' '}
-        <a href={introductionURL}>Introduction</a>
-      </div>
-      <div>
-        <a href={downloadTranscriptURL}>Download Transcript</a>
-      </div>
+      {links.map(({ href, text }: ControlBarLinkItem) => (
+        <div key={`${text}-${href}`}>
+          <a href={href}>{text}</a>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,14 +8,13 @@ import {
 import AnnotationViewer from './AnnotationViewer/AnnotationViewer';
 import { getVideoConfigFromSlug } from './api';
 import IndexPage from './IndexPage';
-import { IConfig } from './api/interfaces';
+import { ControlBarLinkConfig, IConfig } from './api/interfaces';
 
 interface AnnotationViewerFromSlugProps {
   config: IConfig;
 }
 
-function AnnotationViewerFromSlug(props: AnnotationViewerFromSlugProps) {
-  const { config } = props;
+function AnnotationViewerFromSlug({ config }: AnnotationViewerFromSlugProps) {
   const { slug } = useParams<{ slug: string }>();
 
   const videoConfig = getVideoConfigFromSlug(config, slug);
@@ -25,10 +24,31 @@ function AnnotationViewerFromSlug(props: AnnotationViewerFromSlugProps) {
 
   const { callNumber, manifestURL } = videoConfig;
 
+  const { controlBarLinks } = config;
+
   return (
     <AnnotationViewer
       manifestURL={manifestURL}
       callNumber={callNumber || slug}
+      controlBarLinks={(controlBarLinks || [])
+        .filter(({ property }: ControlBarLinkConfig) => property in videoConfig)
+        .map(({ property, label: text }: ControlBarLinkConfig) => {
+          const href = videoConfig[property];
+          if (href === undefined) {
+            // allowing console use for misconfigurations
+            // TODO - should abstract this so we can just
+            // make the no-console exception once
+            // eslint-disable-next-line no-console
+            console.warn(
+              `Property '${property}' not found in link config:`,
+              videoConfig
+            );
+          }
+          return {
+            href,
+            text,
+          };
+        })}
     />
   );
 }

--- a/src/api/iiifManifest.ts
+++ b/src/api/iiifManifest.ts
@@ -1,3 +1,9 @@
+/**
+ * This is not meant to be a faithful and complete representation of the IIIF
+ * manifest specification. Instead it's only intended to represent the
+ * Aviary-flavored IIIF manifests.
+ * */
+
 export interface MultilingualValue<V> {
   [lang: string]: V;
 }

--- a/src/api/interfaces.ts
+++ b/src/api/interfaces.ts
@@ -2,8 +2,16 @@ export interface IVideoConfigEntry {
   slug: string;
   manifestURL: string;
   callNumber: string;
+  [key: string]: string;
+}
+
+export interface ControlBarLinkConfig {
+  property: string;
+  label: string;
 }
 
 export interface IConfig {
   videos: Array<IVideoConfigEntry>;
+  onlyUseCriticalEditions?: boolean;
+  controlBarLinks?: Array<ControlBarLinkConfig>;
 }


### PR DESCRIPTION
This moves introduction and transcript links from the core code to being configurable via the config.json.